### PR TITLE
README: typo fix (Feautures -> Features)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Optional:
 - xlrd_, tablib_
 
 
-Feautures:
+Features:
 -----------
 
 - Simplifies work with coordinates (3D points)


### PR DESCRIPTION
Just a minor typo fix from the README. I am still looking around at the library.
